### PR TITLE
Add scopes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 1. [Create a Slack app](https://api.slack.com/apps)
-1. Enable the Bot user and generate an OAuth token for it
+1. Enable the Bot user, add `chat:write` and `emoji:read` in Permissions>Scopes, and generate an OAuth token for it
 1. [![Deploy to DO](https://mp-assets1.sfo2.digitaloceanspaces.com/deploy-to-do/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/kamaln7/slack-emoji-papertrail/tree/main)
 1. Go back to the Slack App config and click on Event Subscriptions
 1. Enable and paste your app's URL in the Request URL field like so: `https://yourapp.ondigitalocean.app/slack/events`


### PR DESCRIPTION
I just installed it on materialize slack!

During installation I was tripped up by not thinking to add `chat:write` scope so I called it out in readme.